### PR TITLE
Remove the public domain and private address check

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@ var dns = require('dns');
 var eachAsync = require('each-async');
 var onetime = require('onetime');
 var arrify = require('arrify');
-var isPublicDomain = require('is-public-domain');
 var isPortReachable = require('is-port-reachable');
-var ip = require('ip');
 var urlParseLax = require('url-parse-lax');
 
 module.exports = function (hosts, cb) {
@@ -18,15 +16,6 @@ module.exports = function (hosts, cb) {
 			// Ignore `err` as we only care about `address`.
 			// Skip connecting if there is nothing to connect to.
 			if (!address) {
-				done();
-				return;
-			}
-
-			// When a public domain returns a private IP address we declare the host
-			// as unreachable. This will fail intentionally when a intranet resource
-			// uses a public top level domain with a private IP address, which itself
-			// is a violation of RFC 1918 (https://www.ietf.org/rfc/rfc1918.txt).
-			if (isPublicDomain(host.hostname) && ip.isPrivate(address)) {
 				done();
 				return;
 			}

--- a/package.json
+++ b/package.json
@@ -44,9 +44,7 @@
   "dependencies": {
     "arrify": "^1.0.0",
     "each-async": "^1.1.0",
-    "ip": "^0.3.3",
     "is-port-reachable": "^1.0.0",
-    "is-public-domain": "^1.0.0",
     "onetime": "^1.0.0",
     "url-parse-lax": "^1.0.0"
   },


### PR DESCRIPTION
While indeed stashing private IP addresses on public DNS records is bad
form, at least one IaaS provider (AWS) provides a DNS service which
resolves to a public IP when queried from outside, and a private IP when
queried from inside. The presence of that check renders the module
unusable within that provider, if you use DNS names they provide you
with.

Besides that, the mentioned RFC is classified as 'Best Current
Practice', and was issued in 1996. While private IP blocks aren't going
to change, it's possible that authors did not expect DNS servers with
such duality at the time of writing.

That check also isn't documented or tested anywhere.