### PR TITLE
ES2015 and promisify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - '5'
+  - '6'
   - '4'
-  - '0.12'
-  - '0.10'

--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,10 @@
 /* eslint-env browser */
 'use strict';
 const arrify = require('arrify');
+const pAny = require('p-any');
 
 module.exports = hosts => {
-	return Promise.all(arrify(hosts).map(x => {
+	return pAny(arrify(hosts).map(x => {
 		return new Promise(resolve => {
 			const img = new Image();
 
@@ -12,5 +13,5 @@ module.exports = hosts => {
 
 			img.src = `//${x}/favicon.ico?${Date.now()}`;
 		});
-	})).then(hosts => hosts.some(Boolean));
+	}));
 };

--- a/browser.js
+++ b/browser.js
@@ -1,28 +1,16 @@
 /* eslint-env browser */
 'use strict';
-var eachAsync = require('each-async');
-var onetime = require('onetime');
-var arrify = require('arrify');
+const arrify = require('arrify');
 
-module.exports = function (hosts, cb) {
-	cb = onetime(cb);
+module.exports = hosts => {
+	return Promise.all(arrify(hosts).map(x => {
+		return new Promise(resolve => {
+			const img = new Image();
 
-	eachAsync(arrify(hosts), function (host, i, next) {
-		var img = new Image();
+			img.onload = () => resolve(true);
+			img.onerror = () => resolve(false);
 
-		img.onload = function () {
-			cb(true);
-
-			// skip to end
-			next(new Error());
-		};
-
-		img.onerror = function () {
-			next();
-		};
-
-		img.src = '//' + host + '/favicon.ico?' + Date.now();
-	}, function () {
-		cb(false);
-	});
+			img.src = `//${x}/favicon.ico?${Date.now()}`;
+		});
+	})).then(hosts => hosts.some(Boolean));
 };

--- a/index.js
+++ b/index.js
@@ -1,69 +1,50 @@
 'use strict';
-var dns = require('dns');
-var arrify = require('arrify');
-var eachAsync = require('each-async');
-var isPortReachable = require('is-port-reachable');
-var onetime = require('onetime');
-var routerIps = require('router-ips');
-var url = require('url');
-var urlParseLax = require('url-parse-lax');
+const dns = require('dns');
+const url = require('url');
+const arrify = require('arrify');
+const isPortReachable = require('is-port-reachable');
+const routerIps = require('router-ips');
+const urlParseLax = require('url-parse-lax');
+const got = require('got');
+const pify = require('pify');
 
-module.exports = function (dests, cb) {
-	cb = onetime(cb);
+const checkRedirection = (host, port) => {
+	const protocol = port === 80 ? 'http:' : 'https:';
 
-	eachAsync(arrify(dests), function (dest, i, done) {
-		dest = urlParseLax(dest);
+	return got(host, {protocol}).then(res => {
+		const redirectHost = url.parse(res.headers.location || '').host;
 
-		var host = dest.hostname;
-		var port = dest.port || 80;
+		if (routerIps.has(redirectHost)) {
+			return false;
+		}
 
-		dns.lookup(host, function (_, address) {
-			// Ignore `err` as we only care about `address`.
-			// Skip connecting if there is nothing to connect to.
-			if (!address) {
-				done();
-				return;
-			}
-
-			// When the returned address is a well-known router ip, we might
-			// have been redirected to a router's captive portal.
-			if (routerIps.indexOf(address) !== -1) {
-				done();
-				return;
-			}
-
-			if (port === 80 || port === 443) {
-				// Try to detect HTTP redirection by checking if the `Location`
-				// header contains a well-known router ip.
-				// https://github.com/sindresorhus/is-reachable/issues/3#issuecomment-138735338
-				require(port === 80 ? 'http' : 'https').get({host: host}, function (res) {
-					var redirectHost = url.parse(res.headers.location || '').host;
-					if (routerIps.indexOf(redirectHost) === -1) {
-						cb(null, true);
-
-						// skip to end
-						done(new Error());
-					} else {
-						done();
-					}
-				}).on('error', function () {
-					done();
-				});
-			} else {
-				// Just test if the port answers to a SYN
-				isPortReachable(port, {host: address}, function (_, reachable) {
-					if (reachable) {
-						cb(null, true);
-
-						// skip to end
-						done(new Error());
-					} else {
-						done();
-					}
-				});
-			}
-		});
-	}, function () {
-		cb(null, false);
+		return true;
 	});
+};
+
+module.exports = dests => {
+	return Promise.all(arrify(dests).map(x => {
+		x = urlParseLax(x);
+
+		const host = x.hostname;
+		const port = x.port || 80;
+
+		return pify(dns.lookup)(host)
+			.then(address => {
+				if (!address) {
+					return false;
+				}
+
+				if (routerIps.has(address)) {
+					return false;
+				}
+
+				if (port === 80 || port === 443) {
+					return checkRedirection(host, port);
+				}
+
+				return pify(isPortReachable)(port, {host: address});
+			})
+			.catch(() => false);
+	})).then(dests => dests.some(Boolean));
 };

--- a/package.json
+++ b/package.json
@@ -52,5 +52,8 @@
   "devDependencies": {
     "ava": "*",
     "xo": "*"
+  },
+  "xo": {
+    "esnext": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "browser": "browser.js",
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava test.js"
@@ -43,10 +43,10 @@
   ],
   "dependencies": {
     "arrify": "^1.0.1",
-    "each-async": "^1.1.1",
+    "got": "^6.3.0",
     "is-port-reachable": "^1.0.0",
-    "onetime": "^1.1.0",
-    "router-ips": "^0.2.0",
+    "pify": "^2.3.0",
+    "router-ips": "^0.3.0",
     "url-parse-lax": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "got": "^6.3.0",
-    "is-port-reachable": "^1.0.0",
+    "is-port-reachable": "^2.0.0",
+    "p-any": "^1.0.0",
     "pify": "^2.3.0",
     "router-ips": "^0.3.0",
     "url-parse-lax": "^1.0.0"

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ isReachable('google.com:80').then(reachable => {
 
 ### isReachable(hosts)
 
-Returns a promise for a boolean which is `true` if any of the `hosts` are reachable.
+Returns a `Promise` for a `boolean` which is `true` if any of the `hosts` are reachable.
 
 #### hosts
 

--- a/readme.md
+++ b/readme.md
@@ -17,12 +17,12 @@ $ npm install --save is-reachable
 ```js
 const isReachable = require('is-reachable');
 
-isReachable('sindresorhus.com', (err, reachable) => {
+isReachable('sindresorhus.com').then(reachable => {
 	console.log(reachable);
 	//=> true
 });
 
-isReachable('google.com:80', (err, reachable) => {
+isReachable('google.com:80').then(reachable => {
 	console.log(reachable);
 	//=> true
 });
@@ -31,30 +31,20 @@ isReachable('google.com:80', (err, reachable) => {
 
 ## Node.js API
 
-### isReachable(hosts, callback)
+### isReachable(hosts)
+
+Returns a promise for a boolean which is `true` if any of the `hosts` are reachable.
 
 #### hosts
 
-Type: `string`, `array`
+Type: `string` `Array`
 
 One or more [hosts](https://nodejs.org/api/url.html) to check.
-
-#### callback(error, reachable)
-
-Type: `function`
-
-`error` is there only by Node.js convention and is always `null`.
-
-##### reachable
-
-Type: `boolean`
-
-Is `true` if *any* of the `hosts` are reachable.
 
 
 ## Browser API
 
-Same as above except the `callback` doesn't have an `error` parameter.
+Same as above.
 
 
 ## Contributors

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,16 +1,16 @@
 // need to test manually in devtools
 // $ browserify test-browser.js > tmp.js
 'use strict';
-var isReachable = require('./browser');
+const isReachable = require('./browser');
 
-isReachable('google.com', function (reachable) {
+isReachable('google.com').then(reachable => {
 	console.log('reachable', reachable);
 });
 
-isReachable('google.com:80', function (reachable) {
+isReachable('google.com:80').then(reachable => {
 	console.log('reachable', reachable);
 });
 
-isReachable('343645335341233123125235623452344123.com', function (reachable) {
+isReachable('343645335341233123125235623452344123.com').then(reachable => {
 	console.log('not reachable', reachable);
 });

--- a/test.js
+++ b/test.js
@@ -1,23 +1,14 @@
 import test from 'ava';
-import fn from './';
+import m from './';
 
-test.cb('main', t => {
-	fn('google.com', (_, reachable) => {
-		t.true(reachable);
-		t.end();
-	});
+test('main', async t => {
+	t.true(await m('google.com'));
 });
 
-test.cb('port', t => {
-	fn('google.com:80', (_, reachable) => {
-		t.true(reachable);
-		t.end();
-	});
+test('port', async t => {
+	t.true(await m('google.com:80'));
 });
 
-test.cb('unreachable', t => {
-	fn('343645335341233123125235623452344123.com', (_, reachable) => {
-		t.false(reachable);
-		t.end();
-	});
+test('unreachable', async t => {
+	t.false(await m('343645335341233123125235623452344123.com'));
 });


### PR DESCRIPTION
Used `got` instead of core `http`/`https` for convenience. Could switch back if it's too heavyweight.

Fixes #8.