### PR TITLE
Removing readonly from index.d.ts 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -33,7 +33,7 @@ import isReachable = require('is-reachable');
 ```
 */
 declare function isReachable(
-	targets: string | readonly string[],
+	targets: string | string[],
 	options?: isReachable.Options
 ): Promise<boolean>;
 


### PR DESCRIPTION
In order to suppoer importing this library as - 
import * as isReachable from 'is-reachable'
instead of - 
const isReachable = require('is-reachable')

This syntax needs to be removed as its not a valid TS.