### PR TITLE
Remove support for well-known protocols - fixes #37

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ const arrify = require('arrify');
 const got = require('got');
 const isPortReachable = require('is-port-reachable');
 const pAny = require('p-any');
-const portNumbers = require('port-numbers');
 const pTimeout = require('p-timeout');
 const prependHttp = require('prepend-http');
 const routerIps = require('router-ips');
@@ -14,27 +13,30 @@ const URL = require('url-parse');
 
 const dnsLookupP = promisify(dns.lookup);
 
-const checkRedirection = async target => {
+const checkHttp = async url => {
 	let response;
 	try {
-		response = await got(target, {rejectUnauthorized: false});
+		response = await got(url, {rejectUnauthorized: false});
 	} catch (_) {
 		return false;
 	}
 
-	const url = new URL(response.headers.location || 'x://x');
-	return !routerIps.has(url.hostname);
+	if (response.headers && response.headers.location) {
+		const url = new URL(response.headers.location);
+		const hostname = url.hostname.replace(/^\[/, '').replace(/\]$/, ''); // Strip [] from IPv6
+		return !routerIps.has(hostname);
+	}
+
+	return true;
 };
 
 const getAddress = async hostname => net.isIP(hostname) ? hostname : (await dnsLookupP(hostname)).address;
 
 const isTargetReachable = async target => {
 	const url = new URL(prependHttp(target));
-	url.port = Number(url.port) || portNumbers.getPort(url.protocol.slice(0, -1)).port || 80;
 
-	if (!/^[a-z]+:\/\//.test(target)) {
-		const service = portNumbers.getService(url.port);
-		url.protocol = ((service && service.name) ? service.name : 'unknown') + ':';
+	if (!url.port) {
+		url.port = url.protocol === 'http:' ? 80 : 443;
 	}
 
 	let address;
@@ -48,8 +50,8 @@ const isTargetReachable = async target => {
 		return false;
 	}
 
-	if (url.protocol === 'http:' || url.protocol === 'https:') {
-		return checkRedirection(url.toString());
+	if ([80, 443].includes(url.port)) {
+		return checkHttp(url.toString());
 	}
 
 	return isPortReachable(url.port, {host: address});

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
 		"is-port-reachable": "^2.0.1",
 		"p-any": "^2.1.0",
 		"p-timeout": "^3.1.0",
-		"port-numbers": "^4.0.7",
 		"prepend-http": "^2.0.0",
 		"router-ips": "^1.0.0",
 		"url-parse": "^1.4.6"

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ const isReachable = require('is-reachable');
 	console.log(await isReachable('sindresorhus.com'));
 	//=> true
 
-	console.log(await isReachable('google.com:80'));
+	console.log(await isReachable('google.com:443'));
 	//=> true
 })();
 ```
@@ -41,9 +41,7 @@ Returns a `Promise<boolean>` which is `true` if any of the `targets` are reachab
 
 Type: `string | string[]`
 
-One or more targets to check. Can either be a full [URL](https://nodejs.org/api/url.html) like `https://hostname`, `hostname:port` or just `hostname`. When the protocol is missing from a target `http` is assumed.
-
-[Well-known protocols][] are supported (for example: `ftp://`, `mysql://`, `redis://` and more).
+One or more targets to check. Can either be `hostname:port`, a URL like `https://hostname:port` or even just `hostname`. `port` must be specified if protocol is not `http:` or `https:` and defaults to `443`. Protocols other than `http:` and `https:` are not supported.
 
 #### options
 

--- a/test.js
+++ b/test.js
@@ -30,8 +30,8 @@ test('ftp host and port', async t => {
 	t.true(await isReachable('speedtest.tele2.net:21'));
 });
 
-test('ftp url', async t => {
-	t.true(await isReachable('ftp://speedtest.tele2.net'));
+test('imap host and port', async t => {
+	t.true(await isReachable('imap.gmail.com:995'));
 });
 
 test('unreachable hostname', async t => {


### PR DESCRIPTION
Now, only http: and https: are supported for port-less URLs. Also improved the redirect check.

The removal of non-http protocols is because of this oddity in the URL standard:

````
> new URL("ftp://google.com:21").port
''
> new URL("https://google.com:21").port
'21'
````

This should be released as `semver-major`.

Fixes #37