### PR TITLE
Add test for parked domain

### DIFF
--- a/test.js
+++ b/test.js
@@ -53,3 +53,7 @@ test('with timeout', async t => {
 test('with impossible timeout', async t => {
 	t.false(await isReachable('https://google.com', {timeout: 1}));
 });
+
+test.failing('parked domain', async t => {
+	t.false(await isReachable('http://find.myrecipes.com'));
+});


### PR DESCRIPTION
Currently failing test for a parked domain, as requested in #40:

![image](https://user-images.githubusercontent.com/19352442/71642705-83ae6500-2c7d-11ea-8004-377761a16bb6.png)
