### PR TITLE
feat: allow to perform an http check non HTTP(S) ports

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,12 @@ Default: `5000`
 
 Timeout in milliseconds after which a request is considered failed.
 
+##### forceHttpCheck
+
+Type: `boolean`<br>
+Default: `false`
+
+Perform an HTTP check even if one or more targets is not on 80 or 443 port.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -29,7 +29,8 @@ test('multiple https urls', async t => {
 
 test('http server on custom port', async t => {
 	const server = http.createServer((_, res) => {
-		res.writeHead(200, {'Content-Type': 'text/plain'}).end();
+		res.writeHead(200);
+		res.end();
 	}).listen(8080);
 
 	t.true(await isReachable('http://localhost:8080', {forceHttpCheck: true}));

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import {promisify} from 'util';
 import dns from 'dns';
+import http from 'http';
 import test from 'ava';
 import isReachable from '.';
 
@@ -26,6 +27,20 @@ test('multiple https urls', async t => {
 	t.true(await isReachable(['https://google.com', 'https://baidu.com']));
 });
 
+test('http server on custom port', async t => {
+	const server = http.createServer((_, res) => {
+		res.writeHead(200, {'Content-Type': 'text/plain'}).end();
+	}).listen(8080);
+
+	t.true(await isReachable('http://localhost:8080', {forceHttpCheck: true}));
+
+	server.close();
+});
+
+test('unreachable http server on custom port', async t => {
+	t.false(await isReachable('http://localhost:8081', {forceHttpCheck: true}));
+});
+
 test('ftp host and port', async t => {
 	t.true(await isReachable('speedtest.tele2.net:21'));
 });
@@ -37,7 +52,6 @@ test('imap host and port', async t => {
 test('unreachable hostname', async t => {
 	t.false(await isReachable('343645335341233123125235623452344123.local'));
 });
-
 test('unknown service', async t => {
 	t.false(await isReachable('343645335341233123125235623452344123.local:-1'));
 });


### PR DESCRIPTION
Hello,

I have some HTTP servers listening on some specific ports.
Checking with `is-port-reachable` is not enough as some of their sockets are opened before the http server is able to respond

I think this would be a nice addition :)