### PR TITLE
Force HTTP check under corresponding protocols

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,10 +38,11 @@ const checkHttp = async (url, timeout) => {
 const getAddress = async hostname => net.isIP(hostname) ? hostname : (await dnsLookupP(hostname)).address;
 
 const isTargetReachable = timeout => async target => {
+	const isHTTP = target.startsWith('https://') || target.startsWith('http://');
 	const url = new URL(prependHttp(target));
 
-	if (!url.port) {
-		url.port = url.protocol === 'http:' ? 80 : 443;
+	if (!url.port && !isHTTP) {
+		url.port = 443;
 	}
 
 	let address;
@@ -55,7 +56,7 @@ const isTargetReachable = timeout => async target => {
 		return false;
 	}
 
-	if ([80, 443].includes(url.port)) {
+	if (isHTTP) {
 		return checkHttp(url.toString(), timeout);
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import {promisify} from 'util';
 import dns from 'dns';
+import http from 'http';
 import test from 'ava';
 import isReachable from '.';
 
@@ -24,6 +25,18 @@ test('ip and protocol', async t => {
 
 test('multiple https urls', async t => {
 	t.true(await isReachable(['https://google.com', 'https://baidu.com']));
+});
+
+test('http server on custom port', async t => {
+	const server = http.createServer((_, response) => {
+		response.writeHead(200).end();
+	}).listen(8080);
+	t.true(await isReachable('http://localhost:8080'));
+	server.close();
+});
+
+test('unreachable http server on custom port', async t => {
+	t.false(await isReachable('http://localhost:8081'));
 });
 
 test('imap host and port', async t => {


### PR DESCRIPTION
Fixes #55.

Since URL object with http or https protocol and default port(80 or 443)
will not show the port, the port is only assigned to default port 443
when the protocol is neither one of them.